### PR TITLE
chore: export Port configuration (blueprints) - 2026-05-25

### DIFF
--- a/port/blueprints/wizControl.json
+++ b/port/blueprints/wizControl.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "wizControl",
+  "description": "This blueprint represents a wiz source rule",
+  "title": "Wiz Control",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "controlDescription": {
+        "type": "string",
+        "title": "Control Description",
+        "description": "the control description"
+      },
+      "resolutionRecommendation": {
+        "type": "string",
+        "title": "Control Recommendation",
+        "description": "the control recommendation on resolving issues"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/wizHostedTechnology.json
+++ b/port/blueprints/wizHostedTechnology.json
@@ -1,0 +1,45 @@
+{
+  "identifier": "wizHostedTechnology",
+  "description": "This blueprint represents a wiz hosted technology",
+  "title": "Wiz Hosted Technology",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "detectionMethods": {
+        "title": "Detection Methods",
+        "type": "array"
+      },
+      "installedPackages": {
+        "title": "Installed Packages",
+        "type": "array"
+      },
+      "firstSeen": {
+        "title": "First Seen",
+        "type": "string",
+        "format": "date-time"
+      },
+      "updatedAt": {
+        "title": "Updated At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "cpe": {
+        "title": "CPE",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "technology": {
+      "title": "Technology",
+      "description": "The technology that this hosted technology is associated with",
+      "target": "wizTechnology",
+      "required": false,
+      "many": false
+    }
+  }
+}

--- a/port/blueprints/wizIssue.json
+++ b/port/blueprints/wizIssue.json
@@ -1,0 +1,168 @@
+{
+  "identifier": "wizIssue",
+  "description": "This blueprint represents a wiz issue",
+  "title": "Wiz Issue",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "url": {
+        "type": "string",
+        "title": "Issue URL",
+        "format": "url",
+        "description": "the link to the issue"
+      },
+      "status": {
+        "title": "Status",
+        "type": "string",
+        "enum": [
+          "OPEN",
+          "IN_PROGRESS",
+          "RESOLVED",
+          "REJECTED"
+        ],
+        "enumColors": {
+          "OPEN": "blue",
+          "IN_PROGRESS": "orange",
+          "RESOLVED": "green",
+          "REJECTED": "darkGray"
+        }
+      },
+      "severity": {
+        "title": "Severity",
+        "type": "string",
+        "enum": [
+          "INFORMATIONAL",
+          "LOW",
+          "MEDIUM",
+          "HIGH",
+          "CRITICAL"
+        ],
+        "enumColors": {
+          "INFORMATIONAL": "blue",
+          "LOW": "yellow",
+          "MEDIUM": "orange",
+          "HIGH": "red",
+          "CRITICAL": "red"
+        }
+      },
+      "vulnerabilityType": {
+        "title": "Vulnerability Type",
+        "type": "string"
+      },
+      "wizIssueID": {
+        "title": "Wiz Issue ID",
+        "type": "string"
+      },
+      "cloudResourceType": {
+        "title": "Cloud Resource Type",
+        "type": "string"
+      },
+      "resourceName": {
+        "title": "Resource Name",
+        "type": "string"
+      },
+      "cloudPlatform": {
+        "title": "Cloud Platform",
+        "type": "string"
+      },
+      "linkToResource": {
+        "icon": "Wiz",
+        "title": "Link to Cloud Resource",
+        "type": "string",
+        "format": "url"
+      },
+      "cloudResourceID": {
+        "title": "Cloud Resource ID",
+        "type": "string"
+      },
+      "cloudRegion": {
+        "title": "Cloud Region",
+        "type": "string"
+      },
+      "resourceGroupExternalId": {
+        "title": "Resource Group External ID",
+        "type": "string"
+      },
+      "subscriptionExternalId": {
+        "title": "Subscription External ID",
+        "type": "string"
+      },
+      "subscriptionName": {
+        "title": "Subscription Name",
+        "type": "string"
+      },
+      "subscriptionTags": {
+        "title": "Subscription Tags",
+        "type": "object"
+      },
+      "resourceTags": {
+        "title": "Resource Tags",
+        "type": "object"
+      },
+      "vulnerability": {
+        "title": "Vulnerability",
+        "type": "object",
+        "description": "The identified security risk"
+      },
+      "notes": {
+        "title": "Notes",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "title": "Created At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "updatedAt": {
+        "title": "Updated At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "dueAt": {
+        "title": "Due At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "resolvedAt": {
+        "title": "Resolved At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "statusChangedAt": {
+        "title": "Status ChangedAt",
+        "type": "string",
+        "format": "date-time"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "control": {
+      "title": "Control",
+      "description": "The control that flagged this issue",
+      "target": "wizControl",
+      "required": false,
+      "many": false
+    },
+    "serviceTickets": {
+      "title": "Service Tickets",
+      "description": "The service tickets belonging to this issue",
+      "target": "wizServiceTicket",
+      "required": false,
+      "many": true
+    },
+    "projects": {
+      "title": "Affected Projects",
+      "description": "The projects affected by this issue",
+      "target": "wizProject",
+      "required": false,
+      "many": true
+    }
+  }
+}

--- a/port/blueprints/wizProject.json
+++ b/port/blueprints/wizProject.json
@@ -1,0 +1,38 @@
+{
+  "identifier": "wizProject",
+  "description": "This blueprint represents a wiz project",
+  "title": "Wiz Project",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "archived": {
+        "type": "boolean",
+        "title": "Archived?",
+        "description": "Is the project archived?"
+      },
+      "businessUnit": {
+        "type": "string",
+        "title": "Business Unit",
+        "description": "the business unit of the project"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "description": "the project description"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "issues": {
+      "title": "Issues",
+      "description": "The issues affecting this project",
+      "target": "wizIssue",
+      "required": false,
+      "many": true
+    }
+  }
+}

--- a/port/blueprints/wizRepository.json
+++ b/port/blueprints/wizRepository.json
@@ -1,0 +1,51 @@
+{
+  "identifier": "wizRepository",
+  "description": "This blueprint represents a wiz repository",
+  "title": "Wiz Repository",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "url": {
+        "title": "URL",
+        "type": "string",
+        "format": "url"
+      },
+      "platform": {
+        "title": "Platform",
+        "type": "string"
+      },
+      "public": {
+        "title": "Public",
+        "type": "boolean"
+      },
+      "archived": {
+        "title": "Archived",
+        "type": "boolean"
+      },
+      "visibility": {
+        "title": "Visibility",
+        "type": "string"
+      },
+      "organization": {
+        "title": "Organization",
+        "type": "string"
+      },
+      "branches": {
+        "title": "Branches",
+        "type": "array"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "projects": {
+      "title": "Projects",
+      "target": "wizProject",
+      "required": false,
+      "many": false
+    }
+  }
+}

--- a/port/blueprints/wizServiceTicket.json
+++ b/port/blueprints/wizServiceTicket.json
@@ -1,0 +1,21 @@
+{
+  "identifier": "wizServiceTicket",
+  "description": "This blueprint represents a wiz service ticket",
+  "title": "Wiz Service Ticket",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "url": {
+        "type": "string",
+        "title": "Ticket URL",
+        "format": "url",
+        "description": "the service ticket URL"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/wizTechnology.json
+++ b/port/blueprints/wizTechnology.json
@@ -1,0 +1,67 @@
+{
+  "identifier": "wizTechnology",
+  "description": "This blueprint represents a wiz technology",
+  "title": "Wiz Technology",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "description": {
+        "title": "Description",
+        "type": "string"
+      },
+      "categories": {
+        "title": "Categories",
+        "type": "array"
+      },
+      "usage": {
+        "title": "Usage",
+        "type": "string"
+      },
+      "status": {
+        "title": "Status",
+        "type": "string"
+      },
+      "risk": {
+        "title": "Risk",
+        "type": "string"
+      },
+      "note": {
+        "title": "Note",
+        "type": "string"
+      },
+      "ownerName": {
+        "title": "Owner Name",
+        "type": "string"
+      },
+      "businessModel": {
+        "title": "Business Model",
+        "type": "string"
+      },
+      "popularity": {
+        "title": "Popularity",
+        "type": "number"
+      },
+      "projectCount": {
+        "title": "Project Count",
+        "type": "number"
+      },
+      "codeRepoCount": {
+        "title": "Code Repo Count",
+        "type": "number"
+      },
+      "isCloudService": {
+        "title": "Is Cloud Service",
+        "type": "boolean"
+      },
+      "supportedOperatingSystems": {
+        "title": "Supported Operating Systems",
+        "type": "array"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/wizVulnerabilityFinding.json
+++ b/port/blueprints/wizVulnerabilityFinding.json
@@ -1,0 +1,155 @@
+{
+  "identifier": "wizVulnerabilityFinding",
+  "description": "This blueprint represents a wiz vulnerability finding",
+  "title": "Wiz Vulnerability Finding",
+  "icon": "Wiz",
+  "schema": {
+    "properties": {
+      "status": {
+        "title": "Status",
+        "type": "string",
+        "enum": [
+          "OPEN",
+          "IN_PROGRESS",
+          "RESOLVED",
+          "REJECTED"
+        ],
+        "enumColors": {
+          "OPEN": "red",
+          "IN_PROGRESS": "yellow",
+          "RESOLVED": "green",
+          "REJECTED": "lightGray"
+        }
+      },
+      "severity": {
+        "title": "Severity",
+        "type": "string",
+        "enum": [
+          "LOW",
+          "MEDIUM",
+          "HIGH",
+          "CRITICAL",
+          "NONE"
+        ],
+        "enumColors": {
+          "LOW": "olive",
+          "MEDIUM": "yellow",
+          "HIGH": "red",
+          "CRITICAL": "red",
+          "NONE": "lightGray"
+        }
+      },
+      "categories": {
+        "title": "Categories",
+        "type": "array"
+      },
+      "version": {
+        "title": "Version",
+        "type": "string"
+      },
+      "detectionMethod": {
+        "title": "Detection Method",
+        "type": "string"
+      },
+      "score": {
+        "title": "Score",
+        "type": "number"
+      },
+      "description": {
+        "title": "Description",
+        "type": "string"
+      },
+      "firstDetectedAt": {
+        "title": "First Detected At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "publishedDate": {
+        "title": "Published Date",
+        "type": "string",
+        "format": "date-time"
+      },
+      "remediation": {
+        "title": "Remediation",
+        "type": "string"
+      },
+      "environments": {
+        "title": "Environments",
+        "type": "array"
+      },
+      "link": {
+        "title": "Link",
+        "type": "string",
+        "format": "url"
+      },
+      "vulnerabilityExternalId": {
+        "title": "Vulnerability External ID",
+        "type": "string"
+      },
+      "portalUrl": {
+        "title": "Portal URL",
+        "type": "string",
+        "format": "url"
+      },
+      "origin": {
+        "title": "Origin",
+        "type": "string"
+      },
+      "CVEDescription": {
+        "title": "CVE Description",
+        "type": "string"
+      },
+      "hasFix": {
+        "title": "Has Fix",
+        "type": "boolean"
+      },
+      "hasExploit": {
+        "title": "Has Exploit",
+        "type": "boolean"
+      },
+      "isHighProfileThreat": {
+        "title": "Is High Profile Threat",
+        "type": "boolean"
+      },
+      "rootComponent": {
+        "title": "Root Component",
+        "type": "object"
+      },
+      "applicationServices": {
+        "title": "Application Services",
+        "type": "array"
+      },
+      "updatedAt": {
+        "title": "Updated At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "resolvedAt": {
+        "title": "Resolved At",
+        "type": "string",
+        "format": "date-time"
+      },
+      "detailedName": {
+        "type": "string",
+        "title": "Detailed Name"
+      },
+      "artifactMetadata": {
+        "type": "object",
+        "title": "Artifact Metadata"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "projects": {
+      "title": "Projects",
+      "description": "The projects affected by this vulnerability finding",
+      "target": "wizProject",
+      "required": false,
+      "many": true
+    }
+  }
+}


### PR DESCRIPTION
## What this PR does
Backs up all Wiz blueprint definitions from Port into JSON files under `port/blueprints/`.

## Exported resources
| Type | Identifier |
| --- | --- |
| blueprint | wizControl |
| blueprint | wizServiceTicket |
| blueprint | wizProject |
| blueprint | wizTechnology |
| blueprint | wizVulnerabilityFinding |
| blueprint | wizRepository |
| blueprint | wizIssue |
| blueprint | wizHostedTechnology |
