### PR TITLE
chore: backup all blueprints and actions JSON (2026-05-26)

### DIFF
--- a/port/actions/_onboard_existing_team.json
+++ b/port/actions/_onboard_existing_team.json
@@ -1,0 +1,41 @@
+{
+  "identifier": "_onboard_existing_team",
+  "title": "Add team members",
+  "icon": "Team",
+  "description": "Add members to an existing team",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "blueprintIdentifier": "_team",
+    "userInputs": {
+      "properties": {
+        "team_members": {
+          "type": "array",
+          "title": "Team members",
+          "items": { "type": "string", "format": "entity", "blueprint": "_user" }
+        }
+      }
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.getport.io/v1/migrations",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": {},
+    "body": {
+      "sourceBlueprint": "_user",
+      "mapping": {
+        "blueprint": "_user",
+        "filter": ".identifier as $item | {{ .inputs.team_members | map(.identifier) }}  | any(. == $item)",
+        "entity": {
+          "identifier": ".identifier",
+          "team": ".team + [\"{{ .entity.identifier }}\"] | unique"
+        }
+      }
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/_onboard_your_user.json
+++ b/port/actions/_onboard_your_user.json
@@ -1,0 +1,44 @@
+{
+  "identifier": "_onboard_your_user",
+  "title": "Register your user",
+  "icon": "User",
+  "description": "Register your user and connect it to your user in other tools",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
+    "blueprintIdentifier": "_user",
+    "userInputs": {
+      "properties": {
+        "teams": {
+          "type": "array",
+          "title": "Teams",
+          "icon": "Team",
+          "items": { "type": "string", "format": "entity", "blueprint": "_team" },
+          "default": { "jqQuery": ".user.teamsIdentifiers" },
+          "visible": true
+        },
+        "your_user": {
+          "type": "string",
+          "title": "Your user",
+          "blueprint": "_user",
+          "format": "entity",
+          "default": { "jqQuery": ".user.email" },
+          "visible": false
+        }
+      },
+      "order": ["teams"]
+    }
+  },
+  "invocationMethod": {
+    "type": "UPSERT_ENTITY",
+    "blueprintIdentifier": "_user",
+    "mapping": {
+      "identifier": "{{.trigger.by.user.email}}",
+      "team": "{{.inputs.teams | (if . then map(.identifier) else [] end)}}",
+      "icon": "DefaultBlueprint",
+      "properties": {}
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/incident_triage_automation.json
+++ b/port/actions/incident_triage_automation.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "incident_triage_automation",
+  "title": "Auto-Triage New Incidents",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ENTITY_UPDATED", "blueprintIdentifier": "incident" },
+    "condition": { "type": "JQ", "expressions": [], "combinator": "and" }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.port.io/v1/ai/invoke",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "Content-Type": "application/json" },
+    "body": {
+      "userPrompt": "A new incident has been created in Port. Load the skill 'sre-incident-triage' using the load_skill MCP tool and follow its instructions exactly to triage this incident.\n\nIncident context:\n- Incident ID: {{.event.diff.after.identifier}}\n- Title: {{.event.diff.after.title}}\n- Properties: {{.event.diff.after.properties}}\n- Relations: {{.event.diff.after.relations}}",
+      "tools": ["^(list|get|search|track|load|describe)_.*", "dynatrace_.*"],
+      "mcpServers": [{ "identifier": "dynatrace" }],
+      "systemPrompt": "You are an incident triage assistant embedded in Port.",
+      "executionMode": "Automatic",
+      "labels": { "source": "automation", "entity_id": "{{ .event.diff.after.identifier }}" }
+    }
+  },
+  "publish": true
+}

--- a/port/actions/invoke_cursor_agent.json
+++ b/port/actions/invoke_cursor_agent.json
@@ -1,0 +1,34 @@
+{
+  "identifier": "invoke_cursor_agent",
+  "title": "Invoke Cursor Agent",
+  "icon": "Cursor",
+  "description": "Trigger a Cursor Agent to perform a coding task",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "prompt": { "type": "string", "title": "Prompt" },
+        "repository": { "type": "string", "title": "Repository URL" }
+      },
+      "required": ["prompt", "repository"]
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api2.cursor.sh/automations/webhook/54529b37-ee10-4f32-a8e8-0322ec03435d",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": {
+      "Authorization": "Bearer {{ .secrets[\"CURSOR_API_KEY\"] }}",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "prompt": "{{ .inputs.prompt }}",
+      "repository": "{{ .inputs.repository }}"
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/request_mcp_server.json
+++ b/port/actions/request_mcp_server.json
@@ -1,0 +1,44 @@
+{
+  "identifier": "request_mcp_server",
+  "title": "Request New MCP Server",
+  "icon": "Microservice",
+  "description": "Request approval for a new MCP server to be added to the organization's approved registry",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
+    "blueprintIdentifier": "mcpRegistry",
+    "userInputs": {
+      "properties": {
+        "server_name": { "title": "Server Name", "type": "string" },
+        "type": { "title": "Server Type", "type": "string", "enum": ["internal", "external"] },
+        "repository_url": { "title": "Repository URL", "type": "string", "format": "url" },
+        "description": { "title": "Description", "type": "string", "format": "markdown" },
+        "labels": { "title": "Labels", "type": "array", "items": { "type": "string" } },
+        "command": { "title": "Server Command", "type": "string" },
+        "endpoint": { "title": "Endpoint", "type": "string", "format": "url" },
+        "business_justification": { "title": "Business Justification", "type": "string", "format": "markdown" }
+      },
+      "required": ["server_name", "type", "repository_url", "description", "labels"]
+    }
+  },
+  "invocationMethod": {
+    "type": "UPSERT_ENTITY",
+    "blueprintIdentifier": "mcpRegistry",
+    "mapping": {
+      "identifier": "{{ .inputs.server_name | gsub(\" \"; \"-\") | ascii_downcase }}",
+      "title": "{{ .inputs.server_name }}",
+      "properties": {
+        "type": "{{ .inputs.type }}",
+        "status": "pending",
+        "description": "{{ .inputs.description }}",
+        "labels": "{{ .inputs.labels }}",
+        "repository_url": "{{ .inputs.repository_url }}",
+        "command": "{{ .inputs.command }}",
+        "endpoint": "{{ .inputs.endpoint }}"
+      },
+      "relations": { "requestedBy": "{{ .trigger.by.user.email }}" }
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/run_claude_code.json
+++ b/port/actions/run_claude_code.json
@@ -1,0 +1,32 @@
+{
+  "identifier": "run_claude_code",
+  "title": "Run Claude Code",
+  "icon": "Claude",
+  "description": "Open a Claude Code PR on any given repository",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
+    "userInputs": {
+      "properties": {
+        "prompt": { "type": "string", "title": "Prompt", "format": "multi-line" },
+        "service": { "type": "string", "blueprint": "service", "title": "Service", "format": "entity" }
+      },
+      "required": ["prompt", "service"],
+      "order": ["prompt", "service"]
+    }
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<GITHUB_ORG>",
+    "repo": "<GITHUB_REPO>",
+    "workflow": "claude-backend.yaml",
+    "workflowInputs": {
+      "command": "{{ .inputs.prompt }}",
+      "repo_name": "{{ .inputs.service.identifier }}",
+      "run_id": "{{ .run.id }}"
+    },
+    "reportWorkflowStatus": false
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/send_a_slack_message.json
+++ b/port/actions/send_a_slack_message.json
@@ -1,0 +1,36 @@
+{
+  "identifier": "send_a_slack_message",
+  "title": "Send Slack Message",
+  "icon": "Slack",
+  "description": "Sends a notification message to a Slack channel",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
+    "userInputs": {
+      "properties": {
+        "channel": { "title": "Channel ID", "type": "string" },
+        "message": { "title": "Message", "type": "string" }
+      },
+      "required": ["channel", "message"],
+      "order": ["channel", "message"]
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://slack.com/api/chat.postMessage",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": {
+      "RUN_ID": "{{ .run.id }}",
+      "Content-Type": "application/json",
+      "Authorization": "Bearer {{ .secrets.SLACK_BOT_TOKEN }}"
+    },
+    "body": {
+      "channel": "{{ .inputs.channel }}",
+      "text": "{{ .inputs.message }}"
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/set_github_deployment_relations.json
+++ b/port/actions/set_github_deployment_relations.json
@@ -1,0 +1,37 @@
+{
+  "identifier": "set_github_deployment_relations",
+  "title": "Set GitHub Deployment relations",
+  "description": "Set relations between Deployments and services based on the Repository",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ANY_ENTITY_CHANGE", "blueprintIdentifier": "" },
+    "condition": {
+      "type": "JQ",
+      "expressions": [
+        ".diff.before.relations.github_repository != .diff.after.relations.github_repository",
+        ".diff.after.relations.github_repository != null"
+      ],
+      "combinator": "and"
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.getport.io/v1/migrations",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "Content-Type": "application/json", "RUN_ID": "{{ .run.id }}" },
+    "body": {
+      "mapping": {
+        "blueprint": "deployment",
+        "entity": {
+          "identifier": ".identifier",
+          "relations": { "service": "\"{{ .event.context.entityIdentifier }}\"" }
+        },
+        "filter": ".relations.github_pull_request != null and .properties.github_repo_id == \"{{ .event.diff.after.relations.github_repository }}\""
+      },
+      "sourceBlueprint": "deployment"
+    }
+  },
+  "publish": false
+}

--- a/port/actions/set_ownership.json
+++ b/port/actions/set_ownership.json
@@ -1,0 +1,42 @@
+{
+  "identifier": "set_ownership",
+  "title": "Own services",
+  "icon": "Microservice",
+  "description": "Assign service ownership to an existing team",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "blueprintIdentifier": "_team",
+    "userInputs": {
+      "properties": {
+        "services_owned_by_this_team": {
+          "title": "Services owned by this team",
+          "type": "array",
+          "items": { "type": "string", "format": "entity", "blueprint": "service" }
+        }
+      },
+      "required": ["services_owned_by_this_team"]
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.getport.io/v1/migrations",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "RUN_ID": "{{ .run.id }}" },
+    "body": {
+      "sourceBlueprint": "service",
+      "mapping": {
+        "blueprint": "service",
+        "filter": ".identifier as $item | {{ .inputs.services_owned_by_this_team | map(.identifier) }} | any(. == $item)",
+        "entity": {
+          "identifier": ".identifier",
+          "team": ".relations.owning_teams + [\"{{ .entity.identifier }}\"] | unique"
+        }
+      }
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/actions/set_parent_team_relations.json
+++ b/port/actions/set_parent_team_relations.json
@@ -1,0 +1,28 @@
+{
+  "identifier": "set_parent_team_relations",
+  "title": "Set Parent Team relations",
+  "icon": "Team",
+  "description": "Set relations between Teams and the default group when a Team without a parent team is updated",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ANY_ENTITY_CHANGE", "blueprintIdentifier": "_team" },
+    "condition": {
+      "type": "JQ",
+      "expressions": [
+        ".diff.after != null",
+        ".diff.after.properties.type != \"group\"",
+        "(.diff.after.relations.parent_team == null) or (.diff.after.relations.parent_team == \"\")"
+      ],
+      "combinator": "and"
+    }
+  },
+  "invocationMethod": {
+    "type": "UPSERT_ENTITY",
+    "blueprintIdentifier": "_team",
+    "mapping": {
+      "identifier": "{{ .event.diff.after.identifier }}",
+      "relations": { "parent_team": "default-group" }
+    }
+  },
+  "publish": true
+}

--- a/port/actions/set_pull_request_relations.json
+++ b/port/actions/set_pull_request_relations.json
@@ -1,0 +1,37 @@
+{
+  "identifier": "set_pull_request_relations",
+  "title": "Set Pull Request relations",
+  "description": "Set relations between Pull Requests and services based on the Repository",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ANY_ENTITY_CHANGE", "blueprintIdentifier": "" },
+    "condition": {
+      "type": "JQ",
+      "expressions": [
+        ".diff.before.relations.github_repository != .diff.after.relations.github_repository",
+        ".diff.after.relations.github_repository != null"
+      ],
+      "combinator": "and"
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.getport.io/v1/migrations",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "RUN_ID": "{{ .run.id }}", "Content-Type": "application/json" },
+    "body": {
+      "sourceBlueprint": "githubPullRequest",
+      "mapping": {
+        "blueprint": "githubPullRequest",
+        "filter": ".relations.repository == \"{{ .event.diff.after.relations.github_repository }}\"",
+        "entity": {
+          "identifier": ".identifier",
+          "relations": { "service": "\"{{ .event.context.entityIdentifier }}\"" }
+        }
+      }
+    }
+  },
+  "publish": false
+}

--- a/port/actions/set_pull_request_user_relations.json
+++ b/port/actions/set_pull_request_user_relations.json
@@ -1,0 +1,39 @@
+{
+  "identifier": "set_pull_request_user_relations",
+  "title": "Set Pull Requests User Relations",
+  "description": "Set relations between Pull Requests and Users based on the Git User",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ANY_ENTITY_CHANGE", "blueprintIdentifier": "_user" },
+    "condition": {
+      "type": "JQ",
+      "expressions": [
+        ".diff.before.relations.git_hub_user != .diff.after.relations.git_hub_user",
+        ".diff.after.relations.git_hub_user != null"
+      ],
+      "combinator": "and"
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.getport.io/v1/migrations",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "Content-Type": "application/json", "RUN_ID": "{{ .run.id }}" },
+    "body": {
+      "mapping": {
+        "blueprint": "githubPullRequest",
+        "entity": {
+          "identifier": ".identifier",
+          "relations": {
+            "creator": "if \"{{ .event.diff.after.relations.git_hub_user }}\" == .relations.git_hub_creator then \"{{ .event.context.entityIdentifier }}\" else .relations.creator end"
+          }
+        },
+        "filter": "\"{{ .event.diff.after.relations.git_hub_user }}\" as $item | (.relations.git_hub_assignees | any(. == $item)) or ($item == .relations.git_hub_creator) or (.relations.git_hub_reviewers | any(. == $item))"
+      },
+      "sourceBlueprint": "githubPullRequest"
+    }
+  },
+  "publish": true
+}

--- a/port/actions/set_workflow_run_relations.json
+++ b/port/actions/set_workflow_run_relations.json
@@ -1,0 +1,38 @@
+{
+  "identifier": "set_workflow_run_relations",
+  "title": "Set GitHub Workflow Run relations",
+  "icon": "Github",
+  "description": "Set relations between GitHub Workflow Runs and services based on the Repository",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ANY_ENTITY_CHANGE", "blueprintIdentifier": "" },
+    "condition": {
+      "type": "JQ",
+      "expressions": [
+        ".diff.before.relations.github_repository != .diff.after.relations.github_repository",
+        ".diff.after.relations.github_repository != null"
+      ],
+      "combinator": "and"
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.getport.io/v1/migrations",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "RUN_ID": "{{ .run.id }}", "Content-Type": "application/json" },
+    "body": {
+      "sourceBlueprint": "githubWorkflowRun",
+      "mapping": {
+        "blueprint": "githubWorkflowRun",
+        "filter": ".relations.repository == \"{{ .event.diff.after.relations.github_repository }}\"",
+        "entity": {
+          "identifier": ".identifier",
+          "relations": { "service": "\"{{ .event.context.entityIdentifier }}\"" }
+        }
+      }
+    }
+  },
+  "publish": false
+}

--- a/port/actions/trigger_ci_failure_cursor_fixer.json
+++ b/port/actions/trigger_ci_failure_cursor_fixer.json
@@ -1,0 +1,31 @@
+{
+  "identifier": "trigger_ci_failure_cursor_fixer",
+  "title": "Trigger CI Failure Cursor Fixer on Failed Workflow Run",
+  "icon": "Github",
+  "description": "Automatically triggers the CI Failure Cursor Fixer AI agent when a GitHub workflow run conclusion changes to failure.",
+  "trigger": {
+    "type": "automation",
+    "event": { "type": "ANY_ENTITY_CHANGE", "blueprintIdentifier": "githubWorkflowRun" },
+    "condition": {
+      "type": "JQ",
+      "expressions": [
+        ".diff.after.properties.conclusion == \"failure\"",
+        ".diff.before.properties.conclusion != \"failure\""
+      ],
+      "combinator": "and"
+    }
+  },
+  "invocationMethod": {
+    "type": "WEBHOOK",
+    "url": "https://api.port.io/v1/agent/ci_failure_cursor_fixer/invoke",
+    "agent": false,
+    "synchronized": true,
+    "method": "POST",
+    "headers": { "RUN_ID": "{{ .run.id }}", "Content-Type": "application/json" },
+    "body": {
+      "prompt": "A GitHub workflow run has just failed. Analyze and fix the CI failure.\n\nWorkflow Run Details:\n- Entity Identifier: {{ .event.context.entityIdentifier }}\n- Workflow Run Name: {{ .event.diff.after.title }}",
+      "labels": { "source": "CI Failure Automation", "entityIdentifier": "{{ .event.context.entityIdentifier }}" }
+    }
+  },
+  "publish": true
+}

--- a/port/actions/update_incident_triage.json
+++ b/port/actions/update_incident_triage.json
@@ -1,0 +1,39 @@
+{
+  "identifier": "update_incident_triage",
+  "title": "Update Incident Triage",
+  "icon": "DefaultProperty",
+  "description": "Called by AI triage agent to store analysis results",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "incident_id": { "type": "string", "title": "Incident ID" },
+        "ai_suggested_severity": { "type": "string", "title": "AI Suggested Severity", "enum": ["sev1", "sev2", "sev3", "sev4"] },
+        "business_impact": { "type": "string", "title": "Business Impact", "format": "markdown" },
+        "internal_comms_message": { "type": "string", "title": "Internal Communications Message", "format": "markdown" },
+        "status_page_message": { "type": "string", "title": "Status Page Message", "format": "markdown" },
+        "ai_suggested_owner": { "type": "string", "title": "AI Suggested Owner", "format": "user" },
+        "ai_suggested_response_team": { "type": "string", "title": "AI Suggested Response Team", "format": "team" }
+      },
+      "required": ["incident_id", "ai_suggested_severity", "business_impact", "internal_comms_message"]
+    }
+  },
+  "invocationMethod": {
+    "type": "UPSERT_ENTITY",
+    "blueprintIdentifier": "incident",
+    "mapping": {
+      "identifier": "{{ .inputs.incident_id }}",
+      "properties": {
+        "ai_suggested_severity": "{{ .inputs.ai_suggested_severity }}",
+        "business_impact": "{{ .inputs.business_impact }}",
+        "internal_comms_message": "{{ .inputs.internal_comms_message }}",
+        "status_page_message": "{{ .inputs.status_page_message }}",
+        "ai_suggested_owner": "{{ .inputs.ai_suggested_owner }}",
+        "ai_suggested_response_team": "{{ .inputs.ai_suggested_response_team }}"
+      }
+    }
+  },
+  "requiredApproval": false,
+  "publish": true
+}

--- a/port/blueprints/_ai_agent.json
+++ b/port/blueprints/_ai_agent.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "_ai_agent",
+  "title": "AI Agent",
+  "icon": "Details",
+  "ownership": { "type": "Direct", "title": "Owning Teams" },
+  "schema": {
+    "properties": {
+      "description": { "type": "string", "title": "Description" },
+      "status": { "title": "Status", "type": "string", "enum": ["active", "inactive"], "enumColors": { "active": "green", "inactive": "red" }, "default": "active" },
+      "tools": { "items": { "type": "string" }, "type": "array", "title": "Tools", "default": ["^(list|get|search|track|describe)_.*"] },
+      "prompt": { "type": "string", "maxLength": 5000, "title": "Prompt", "format": "markdown" },
+      "execution_mode": { "title": "Execution Mode", "type": "string", "enum": ["Automatic", "Approval Required"], "default": "Approval Required" },
+      "conversation_starters": { "items": { "type": "string" }, "type": "array", "title": "Conversation Starters" },
+      "provider": { "type": "string", "title": "Provider" },
+      "model": { "type": "string", "title": "Model" },
+      "labels": { "type": "object", "title": "Labels" }
+    },
+    "required": ["tools", "status", "prompt"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {
+    "total_invocations": { "title": "Total Invocations", "type": "number", "target": "_ai_invocations", "calculationSpec": { "func": "count", "calculationBy": "entities" } }
+  },
+  "relations": {}
+}

--- a/port/blueprints/_ai_invocations.json
+++ b/port/blueprints/_ai_invocations.json
@@ -1,0 +1,33 @@
+{
+  "identifier": "_ai_invocations",
+  "title": "AI Invocation",
+  "icon": "Star",
+  "description": "For each agent request a match feedback entity will be created",
+  "ownership": { "type": "Inherited", "title": "Owning Teams", "path": "agent" },
+  "schema": {
+    "properties": {
+      "status": { "title": "Status", "type": "string", "enum": ["In Progress", "Completed", "Failed"] },
+      "asked_at": { "type": "string", "title": "Asked At", "format": "date-time" },
+      "replied_at": { "type": "string", "title": "Replied At", "format": "date-time" },
+      "prompt": { "type": "string", "title": "Prompt", "format": "markdown" },
+      "error": { "type": "string", "title": "Error" },
+      "response": { "type": "string", "title": "Response", "format": "markdown" },
+      "execution_logs": { "type": "string", "title": "Execution Logs", "format": "markdown" },
+      "labels": { "type": "object", "title": "Labels" },
+      "quota": { "type": "object", "title": "Quota" },
+      "provider": { "type": "string", "title": "Provider" },
+      "model": { "type": "string", "title": "Model" },
+      "source": { "type": "string", "title": "Source" },
+      "feedback_rating": { "type": "string", "title": "Feedback rating", "enum": ["positive", "negative"] },
+      "feedback_comment": { "type": "string", "title": "Feedback comment" }
+    },
+    "required": ["asked_at", "status"]
+  },
+  "mirrorProperties": { "agent_title": { "title": "agent title", "path": "agent.$title" } },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "agent": { "title": "Agent", "target": "_ai_agent", "required": false, "many": false },
+    "asked_by": { "title": "Asked By", "target": "_user", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/_mcp_server.json
+++ b/port/blueprints/_mcp_server.json
@@ -1,0 +1,22 @@
+{
+  "identifier": "_mcp_server",
+  "title": "MCP Server",
+  "icon": "Details",
+  "description": "External MCP (Model Context Protocol) servers that can be connected to Port",
+  "ownership": { "type": "Direct", "title": "Owning Teams" },
+  "schema": {
+    "properties": {
+      "url": { "icon": "Link", "type": "string", "title": "URL", "description": "The URL of the MCP server", "format": "url" },
+      "description": { "icon": "DefaultProperty", "type": "string", "title": "Description", "description": "Description of the MCP server" },
+      "allowed_tools": { "icon": "DefaultProperty", "type": "array", "title": "Allowed Tools", "description": "Array of regex patterns for tool names that are allowed from this MCP server", "items": { "type": "string" }, "default": [] },
+      "oauth_config": { "icon": "Lock", "type": "object", "title": "OAuth Config", "description": "OAuth configuration for servers without DCR support" },
+      "headers": { "icon": "DefaultProperty", "type": "object", "title": "Headers", "description": "Custom headers to inject when connecting to the MCP server" },
+      "exposed": { "icon": "DefaultProperty", "title": "Expose As Port Connector", "type": "boolean", "description": "If true, this MCP server will be available as a connector in the Port UI", "default": false }
+    },
+    "required": ["url"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/_rule.json
+++ b/port/blueprints/_rule.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "_rule",
+  "title": "Scorecard Rule",
+  "icon": "Star",
+  "description": "This blueprint represents a specific scorecard rule",
+  "schema": {
+    "properties": {
+      "level": { "type": "string", "title": "Level", "enum": ["Basic", "Bronze", "Silver", "Gold"] },
+      "rule_description": { "type": "string", "title": "Rule description" },
+      "query": { "title": "Query", "type": "object" }
+    },
+    "required": ["level", "query"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "of_entities_passed": { "title": "% of entities passed", "calculation": "(.properties.entities_passed/.properties.entities_tested)*100", "type": "number" }
+  },
+  "aggregationProperties": {
+    "entities_tested": { "title": "Entities tested", "type": "number", "target": "_rule_result", "calculationSpec": { "func": "count", "calculationBy": "entities" } },
+    "entities_passed": { "title": "Entities passed", "type": "number", "target": "_rule_result", "query": { "combinator": "and", "rules": [{ "property": "result", "operator": "=", "value": "Passed" }] }, "calculationSpec": { "func": "count", "calculationBy": "entities" } }
+  },
+  "relations": {
+    "scorecard": { "title": "Scorecard", "target": "_scorecard", "required": true, "many": false }
+  }
+}

--- a/port/blueprints/_rule_result.json
+++ b/port/blueprints/_rule_result.json
@@ -1,0 +1,29 @@
+{
+  "identifier": "_rule_result",
+  "title": "Scorecard Rule Result",
+  "icon": "Siren",
+  "description": "This blueprint represents the result of a specific rule test on an entity",
+  "ownership": { "type": "Direct" },
+  "schema": {
+    "properties": {
+      "result": { "title": "Result", "type": "string", "enum": ["Not passed", "Passed"], "enumColors": { "Not passed": "red", "Passed": "green" } },
+      "entity": { "type": "string", "title": "Entity" },
+      "result_last_change": { "type": "string", "title": "Result last change", "format": "date-time" }
+    },
+    "required": ["result", "entity"]
+  },
+  "mirrorProperties": {
+    "level": { "path": "rule.level" },
+    "scorecard": { "path": "rule.scorecard.$title" },
+    "blueprint": { "path": "rule.scorecard.blueprint" }
+  },
+  "calculationProperties": {
+    "entity_link": { "title": "Entity link", "calculation": "\"/\" + .properties.blueprint + \"Entity?identifier=\" + .properties.entity", "type": "string", "format": "url" }
+  },
+  "aggregationProperties": {},
+  "relations": {
+    "__team": { "title": "Team", "target": "_team", "required": false, "many": false },
+    "rule": { "title": "Rule", "target": "_rule", "required": true, "many": false },
+    "_organization": { "title": "Organization", "target": "organization", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/_scorecard.json
+++ b/port/blueprints/_scorecard.json
@@ -1,0 +1,23 @@
+{
+  "identifier": "_scorecard",
+  "title": "Scorecard",
+  "icon": "Score",
+  "description": "This blueprint represents scorecards",
+  "schema": {
+    "properties": {
+      "blueprint": { "type": "string", "title": "Blueprint", "format": "blueprints" },
+      "levels": { "type": "array", "title": "Levels", "items": { "type": "object" } },
+      "filter": { "type": "object", "title": "Filter" }
+    },
+    "required": ["blueprint", "levels"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "of_rules_passed": { "title": "% of rules passed", "calculation": "(.properties.rules_passed/.properties.rules_tested)*10000|round/100", "type": "number" }
+  },
+  "aggregationProperties": {
+    "rules_tested": { "title": "Rules tested", "type": "number", "target": "_rule_result", "calculationSpec": { "func": "count", "calculationBy": "entities" } },
+    "rules_passed": { "title": "Rules passed", "type": "number", "target": "_rule_result", "query": { "combinator": "and", "rules": [{ "property": "result", "operator": "=", "value": "Passed" }] }, "calculationSpec": { "func": "count", "calculationBy": "entities" } }
+  },
+  "relations": {}
+}

--- a/port/blueprints/_team.json
+++ b/port/blueprints/_team.json
@@ -1,0 +1,28 @@
+{
+  "identifier": "_team",
+  "title": "Team",
+  "icon": "Team",
+  "description": "This blueprint is synced with Port teams",
+  "schema": {
+    "properties": {
+      "description": { "type": "string", "title": "Description" },
+      "type": { "description": "Hierarchy level — team (leaf) or group (intermediate)", "enum": ["team", "group"], "enumColors": { "group": "turquoise", "team": "blue" }, "default": "team", "title": "Type", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "parent_team_name": { "title": "Parent Team", "path": "parent_team.$title" }
+  },
+  "calculationProperties": {
+    "deploy_freq_tier": { "title": "Deployment Frequency", "calculation": "if (.properties.total_deployments == null or .properties.total_deployments == 0) then \"Low\" else (if (.properties.services_count != null and .properties.services_count != 0) then ((.properties.deployment_frequency // 0) / .properties.services_count) else 0 end) as $dpf | if $dpf >= 7 then \"Elite\" elif $dpf >= 1 then \"High\" elif $dpf >= 0.25 then \"Medium\" else \"Low\" end end", "type": "string" },
+    "github_lead_time_tier": { "title": "Lead Time for Changes", "calculation": "if (.properties.github_lead_time_for_change == null) then \"Low\" elif .properties.github_lead_time_for_change <= 24 then \"Elite\" elif .properties.github_lead_time_for_change <= 168 then \"High\" elif .properties.github_lead_time_for_change <= 720 then \"Medium\" else \"Low\" end", "type": "string" }
+  },
+  "aggregationProperties": {
+    "size": { "title": "Size", "type": "number", "target": "_user", "calculationSpec": { "func": "count", "calculationBy": "entities" } },
+    "github_open_prs": { "title": "Open PRs", "type": "number", "target": "githubPullRequest", "query": { "combinator": "and", "rules": [{ "operator": "=", "property": "status", "value": "open" }] }, "calculationSpec": { "calculationBy": "entities", "func": "count" } }
+  },
+  "relations": {
+    "organization": { "title": "Organization", "target": "organization", "required": false, "many": false },
+    "parent_team": { "title": "Parent Team", "target": "_team", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/_user.json
+++ b/port/blueprints/_user.json
@@ -1,0 +1,24 @@
+{
+  "identifier": "_user",
+  "title": "User",
+  "icon": "User",
+  "description": "This blueprint is synced with active or invited Port users",
+  "ownership": { "type": "Direct", "title": "Teams" },
+  "schema": {
+    "properties": {
+      "port_type": { "title": "Port Type", "type": "string", "default": "Standard", "enum": ["Standard", "Service Account"] },
+      "port_role": { "title": "Port Role", "type": "string", "default": "Member", "enum": ["Admin", "Moderator", "Member"] },
+      "moderated_blueprints": { "type": "array", "title": "Moderated Blueprints", "items": { "type": "string", "format": "blueprints" } },
+      "status": { "type": "string", "title": "Status", "enum": ["Invited", "Active", "Disabled", "Staged"] }
+    },
+    "required": ["port_role", "status", "port_type"]
+  },
+  "mirrorProperties": {
+    "git_hub_username": { "title": "GitHub username", "path": "git_hub_user.$identifier" }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "git_hub_user": { "title": "GitHub User", "target": "githubUser", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/claude_code_analytics.json
+++ b/port/blueprints/claude_code_analytics.json
@@ -1,0 +1,33 @@
+{
+  "identifier": "claude_code_analytics",
+  "title": "Claude Code Analytics",
+  "icon": "Claude",
+  "description": "Daily Claude Code usage metrics including sessions, lines of code, commits, and PRs",
+  "schema": {
+    "properties": {
+      "record_date": { "type": "string", "format": "date-time", "title": "Record Date (UTC)" },
+      "organization_id": { "type": "string", "title": "Organization ID" },
+      "actor_type": { "type": "string", "title": "Actor Type" },
+      "actor_name": { "type": "string", "title": "Actor Name" },
+      "terminal_type": { "type": "string", "title": "Terminal Type" },
+      "num_sessions": { "type": "number", "title": "Sessions" },
+      "lines_added": { "type": "number", "title": "Lines Added" },
+      "lines_removed": { "type": "number", "title": "Lines Removed" },
+      "commits": { "type": "number", "title": "Commits by Claude Code" },
+      "pull_requests": { "type": "number", "title": "Pull Requests by Claude Code" },
+      "edit_tool_accepted": { "type": "number", "title": "Edit Tool Accepted" },
+      "edit_tool_rejected": { "type": "number", "title": "Edit Tool Rejected" },
+      "write_tool_accepted": { "type": "number", "title": "Write Tool Accepted" },
+      "write_tool_rejected": { "type": "number", "title": "Write Tool Rejected" },
+      "model_breakdown": { "type": "array", "title": "Model Breakdown" }
+    },
+    "required": ["record_date", "organization_id"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "total_lines_changed": { "title": "Total Lines Changed", "calculation": ".properties.lines_added + .properties.lines_removed", "type": "number" },
+    "edit_acceptance_rate": { "title": "Edit Acceptance Rate", "calculation": "if (.properties.edit_tool_accepted + .properties.edit_tool_rejected) > 0 then (.properties.edit_tool_accepted / (.properties.edit_tool_accepted + .properties.edit_tool_rejected)) * 100 else 0 end", "type": "number" }
+  },
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/claude_cost_record.json
+++ b/port/blueprints/claude_cost_record.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "claude_cost_record",
+  "title": "Claude AI Cost Record",
+  "icon": "Claude",
+  "description": "Daily cost tracking for Claude API usage",
+  "schema": {
+    "properties": {
+      "record_date": { "type": "string", "format": "date-time", "title": "Record Date (UTC)" },
+      "amount": { "type": "number", "title": "Cost Amount" },
+      "currency": { "type": "string", "title": "Currency" }
+    },
+    "required": ["record_date"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/claude_model_usage.json
+++ b/port/blueprints/claude_model_usage.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "claude_model_usage",
+  "title": "Claude AI Model Usage",
+  "icon": "Claude",
+  "description": "Usage metrics broken down by Claude model type",
+  "schema": {
+    "properties": {
+      "record_date": { "type": "string", "format": "date-time", "title": "Record Date (UTC)" },
+      "model": { "type": "string", "title": "Model" },
+      "uncached_input_tokens": { "type": "number", "title": "Uncached Input Tokens" },
+      "output_tokens": { "type": "number", "title": "Output Tokens" },
+      "cache_read_input_tokens": { "type": "number", "title": "Cache Read Input Tokens" },
+      "cache_creation_5m_tokens": { "type": "number", "title": "Cache Creation (5min) Tokens" },
+      "cache_creation_1h_tokens": { "type": "number", "title": "Cache Creation (1hr) Tokens" },
+      "web_search_requests": { "type": "number", "title": "Web Search Requests" }
+    },
+    "required": ["record_date", "model"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "total_tokens": { "title": "Total Tokens", "calculation": ".properties.uncached_input_tokens + .properties.cache_read_input_tokens + .properties.output_tokens", "type": "number" }
+  },
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/claude_usage_record.json
+++ b/port/blueprints/claude_usage_record.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "claude_usage_record",
+  "title": "Claude AI Usage Record",
+  "icon": "Claude",
+  "description": "Daily Claude AI API usage metrics",
+  "schema": {
+    "properties": {
+      "record_date": { "type": "string", "format": "date-time", "title": "Record Date (UTC)" },
+      "uncached_input_tokens": { "type": "number", "title": "Uncached Input Tokens" },
+      "output_tokens": { "type": "number", "title": "Output Tokens" },
+      "cache_read_input_tokens": { "type": "number", "title": "Cache Read Input Tokens" },
+      "cache_creation_5m_tokens": { "type": "number", "title": "Cache Creation (5min) Tokens" },
+      "cache_creation_1h_tokens": { "type": "number", "title": "Cache Creation (1hr) Tokens" },
+      "web_search_requests": { "type": "number", "title": "Web Search Requests" }
+    },
+    "required": ["record_date"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "total_input_tokens": { "title": "Total Input Tokens", "calculation": ".properties.uncached_input_tokens + .properties.cache_read_input_tokens", "type": "number" },
+    "total_tokens": { "title": "Total Tokens", "calculation": ".properties.uncached_input_tokens + .properties.cache_read_input_tokens + .properties.output_tokens", "type": "number" }
+  },
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/claude_workspace_usage.json
+++ b/port/blueprints/claude_workspace_usage.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "claude_workspace_usage",
+  "title": "Claude AI Workspace Usage",
+  "icon": "Claude",
+  "description": "Usage metrics broken down by workspace",
+  "schema": {
+    "properties": {
+      "record_date": { "type": "string", "format": "date-time", "title": "Record Date (UTC)" },
+      "workspace_id": { "type": "string", "title": "Workspace ID" },
+      "uncached_input_tokens": { "type": "number", "title": "Uncached Input Tokens" },
+      "output_tokens": { "type": "number", "title": "Output Tokens" },
+      "cache_read_input_tokens": { "type": "number", "title": "Cache Read Input Tokens" },
+      "cache_creation_5m_tokens": { "type": "number", "title": "Cache Creation (5min) Tokens" },
+      "cache_creation_1h_tokens": { "type": "number", "title": "Cache Creation (1hr) Tokens" },
+      "web_search_requests": { "type": "number", "title": "Web Search Requests" }
+    },
+    "required": ["record_date", "workspace_id"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "total_tokens": { "title": "Total Tokens", "calculation": ".properties.uncached_input_tokens + .properties.cache_read_input_tokens + .properties.output_tokens", "type": "number" }
+  },
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/deployment.json
+++ b/port/blueprints/deployment.json
@@ -1,0 +1,23 @@
+{
+  "identifier": "deployment",
+  "title": "Deployment",
+  "icon": "Deployment",
+  "description": "A production deployment created from a merged PR to the default branch",
+  "schema": {
+    "properties": {
+      "createdAt": { "format": "date-time", "title": "Deployment Time", "type": "string" },
+      "deploymentStatus": { "enum": ["Success", "Failure", "Pending"], "enumColors": { "Failure": "red", "Pending": "yellow", "Success": "green" }, "title": "Deployment Status", "type": "string" },
+      "environment": { "enum": ["Production", "Staging", "Development"], "enumColors": { "Development": "blue", "Production": "green", "Staging": "yellow" }, "title": "Environment", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "github_lead_time_hours": { "title": "Lead Time for Changes (Hours)", "path": "github_pull_request.cycle_time_hours" },
+    "github_repo_id": { "title": "GitHub Repository ID", "path": "github_pull_request.repository.$identifier" }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "github_pull_request": { "title": "Pull Request", "target": "githubPullRequest", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/environment.json
+++ b/port/blueprints/environment.json
@@ -1,0 +1,10 @@
+{
+  "identifier": "environment",
+  "title": "Environment",
+  "icon": "Environment",
+  "schema": { "properties": {}, "required": [] },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/githubOrganization.json
+++ b/port/blueprints/githubOrganization.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "githubOrganization",
+  "title": "GitHub Organization",
+  "icon": "Github",
+  "description": "This blueprint represents a GitHub organization with engineering metrics",
+  "schema": {
+    "properties": {
+      "login": { "type": "string", "title": "Organization Login" },
+      "id": { "type": "number", "title": "Organization ID" },
+      "nodeId": { "type": "string", "title": "Node ID" },
+      "url": { "type": "string", "title": "URL" },
+      "avatarUrl": { "type": "string", "title": "Avatar URL" },
+      "description": { "type": "string", "title": "Description" },
+      "createdAt": { "format": "date-time", "title": "Created At", "type": "string" },
+      "publicRepos": { "title": "Public Repositories", "type": "number" },
+      "updatedAt": { "format": "date-time", "title": "Updated At", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "organization": { "title": "Organization", "target": "organization", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/githubPullRequest.json
+++ b/port/blueprints/githubPullRequest.json
@@ -1,0 +1,39 @@
+{
+  "identifier": "githubPullRequest",
+  "title": "GitHub Pull Request",
+  "icon": "Github",
+  "schema": {
+    "properties": {
+      "status": { "title": "Status", "type": "string", "enum": ["open", "closed", "merged"], "enumColors": { "closed": "red", "merged": "green", "open": "blue" } },
+      "closedAt": { "title": "Closed At", "type": "string", "format": "date-time" },
+      "mergedAt": { "title": "Merged At", "type": "string", "format": "date-time" },
+      "createdAt": { "title": "Created At", "type": "string", "format": "date-time" },
+      "link": { "format": "url", "type": "string", "title": "Link" },
+      "prNumber": { "type": "number", "title": "PR Number" },
+      "branch": { "type": "string", "title": "Branch" },
+      "cycle_time_hours": { "title": "PR Cycle Time (Hours)", "type": "number" },
+      "has_assignees": { "title": "Has assignees", "type": "boolean" },
+      "has_reviewers": { "title": "Has reviewers", "type": "boolean" },
+      "lead_time_hours": { "title": "Lead Time for Changes (Hours)", "type": "number" },
+      "reviewDecision": { "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED"], "title": "Review Decision", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "reviewer_teams": { "title": "Reviewer Teams", "path": "reviewers.$team" }
+  },
+  "calculationProperties": {
+    "days_old": { "title": "Days Old", "calculation": "(now / 86400) - (.properties.createdAt | capture(\"(?<date>\\\\d{4}-\\\\d{2}-\\\\d{2})\") | .date | strptime(\"%Y-%m-%d\") | mktime / 86400) | floor", "type": "number" },
+    "is_stale": { "title": "Is Stale (7d+)", "calculation": "if (.properties.status == \"open\" and (((now / 86400) - (.properties.createdAt | capture(\"(?<date>\\\\d{4}-\\\\d{2}-\\\\d{2})\") | .date | strptime(\"%Y-%m-%d\") | mktime / 86400) | floor) > 7)) then true else false end", "type": "boolean" }
+  },
+  "aggregationProperties": {},
+  "relations": {
+    "git_hub_creator": { "title": "Creator", "target": "githubUser", "required": false, "many": false },
+    "git_hub_reviewers": { "title": "Reviewers", "target": "githubUser", "required": false, "many": true },
+    "repository": { "title": "Repository", "target": "githubRepository", "required": false, "many": false },
+    "reviewers": { "title": "Reviewers", "target": "_user", "required": false, "many": true },
+    "creator": { "title": "Creator", "target": "_user", "required": false, "many": false },
+    "assignees": { "title": "Assignees", "target": "_user", "required": false, "many": true },
+    "git_hub_assignees": { "title": "Assignees", "target": "githubUser", "required": false, "many": true }
+  }
+}

--- a/port/blueprints/githubRepository.json
+++ b/port/blueprints/githubRepository.json
@@ -1,0 +1,33 @@
+{
+  "identifier": "githubRepository",
+  "title": "GitHub Repository",
+  "icon": "Github",
+  "ownership": { "type": "Direct" },
+  "schema": {
+    "properties": {
+      "readme": { "title": "README", "type": "string", "format": "markdown" },
+      "codeowners": { "title": "CODEOWNERS", "type": "string", "format": "markdown" },
+      "url": { "title": "Repository URL", "type": "string", "format": "url" },
+      "defaultBranch": { "title": "Default branch", "type": "string" },
+      "description": { "title": "Description", "type": "string" },
+      "visibility": { "title": "Visibility", "type": "string" },
+      "language": { "title": "Language", "type": "string" },
+      "last_push": { "title": "Last Repository Push", "type": "string", "format": "date-time" },
+      "gitignore": { "title": "Git Ignore", "type": "string" },
+      "pr_template": { "title": "PR Template", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "cycle_time_trend": { "title": "PR Cycle Time Trend", "calculation": "((.properties.pr_cycle_time // 0) - (.properties.pr_cycle_time_weekly // 0)) as $diff | if $diff > 0 then \"Improving\" elif $diff < 0 then \"Degrading\" else \"Stable\" end", "type": "string" },
+    "stale_pr_share_percent": { "title": "Stale PR Share (%)", "calculation": "if (.properties.open_prs != null and .properties.open_prs != 0) then (.properties.stale_prs_7d / .properties.open_prs) * 100 else 0 end", "type": "number" }
+  },
+  "aggregationProperties": {
+    "open_prs": { "title": "Open PRs", "type": "number", "target": "githubPullRequest", "query": { "combinator": "and", "rules": [{ "operator": "=", "property": "status", "value": "open" }] }, "calculationSpec": { "calculationBy": "entities", "func": "count" } },
+    "merged_prs_last_month": { "title": "Monthly PR Throughput", "type": "number", "target": "githubPullRequest", "query": { "combinator": "and", "rules": [{ "operator": "between", "property": "mergedAt", "value": { "preset": "lastMonth" } }] }, "calculationSpec": { "calculationBy": "entities", "func": "count" } }
+  },
+  "relations": {
+    "githubTeams": { "title": "GitHub Teams", "target": "githubTeam", "required": false, "many": true }
+  }
+}

--- a/port/blueprints/githubTeam.json
+++ b/port/blueprints/githubTeam.json
@@ -1,0 +1,20 @@
+{
+  "identifier": "githubTeam",
+  "title": "GitHub Team",
+  "icon": "Github",
+  "schema": {
+    "properties": {
+      "slug": { "title": "Slug", "type": "string" },
+      "description": { "title": "Description", "type": "string" },
+      "link": { "title": "Link", "type": "string", "format": "url" },
+      "notification_setting": { "title": "Notification Setting", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "organization": { "title": "Organization", "target": "githubOrganization", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/githubUser.json
+++ b/port/blueprints/githubUser.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "githubUser",
+  "title": "GitHub User",
+  "icon": "Github",
+  "schema": {
+    "properties": {
+      "email": { "title": "Email", "type": "string" },
+      "login": { "title": "Login", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "team": { "title": "GitHub Team", "target": "githubTeam", "required": false, "many": true }
+  }
+}

--- a/port/blueprints/githubWorkflow.json
+++ b/port/blueprints/githubWorkflow.json
@@ -1,0 +1,23 @@
+{
+  "identifier": "githubWorkflow",
+  "title": "GitHub Workflow",
+  "icon": "Github",
+  "schema": {
+    "properties": {
+      "createdAt": { "format": "date-time", "title": "Created At", "type": "string" },
+      "last_triggered_at": { "format": "date-time", "title": "Last Triggered At", "type": "string" },
+      "link": { "format": "url", "title": "Link", "type": "string" },
+      "path": { "title": "Path", "type": "string" },
+      "result": { "enum": ["success", "failure", "cancelled", "skipped", "timed_out", "action_required", "neutral", "stale", "startup_failure"], "title": "Result", "type": "string" },
+      "status": { "enum": ["active", "deleted", "disabled_fork", "disabled_inactivity", "disabled_manually"], "title": "Status", "type": "string" },
+      "updatedAt": { "format": "date-time", "title": "Updated At", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "repository": { "title": "Repository", "target": "githubRepository", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/githubWorkflowRun.json
+++ b/port/blueprints/githubWorkflowRun.json
@@ -1,0 +1,32 @@
+{
+  "identifier": "githubWorkflowRun",
+  "title": "GitHub Workflow Run",
+  "icon": "Github",
+  "schema": {
+    "properties": {
+      "conclusion": { "enum": ["success", "failure", "cancelled", "skipped", "timed_out", "action_required", "neutral", "stale", "startup_failure"], "title": "Conclusion", "type": "string" },
+      "createdAt": { "format": "date-time", "title": "Created At", "type": "string" },
+      "headBranch": { "title": "Head Branch", "type": "string" },
+      "link": { "format": "url", "title": "Link", "type": "string" },
+      "name": { "title": "Name", "type": "string" },
+      "runAttempt": { "title": "Run Attempt", "type": "number" },
+      "runNumber": { "title": "Run Number", "type": "number" },
+      "runStartedAt": { "format": "date-time", "title": "Run Started At", "type": "string" },
+      "status": { "enum": ["queued", "in_progress", "completed", "waiting", "requested", "pending"], "title": "Status", "type": "string" },
+      "triggeringActor": { "title": "Triggering Actor", "type": "string" },
+      "updatedAt": { "format": "date-time", "title": "Updated At", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "workflow_current_result": { "title": "Workflow Current Result", "path": "workflow.result" },
+    "workflow_name": { "title": "Workflow Name", "path": "workflow.path" }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "workflow": { "title": "Workflow", "target": "githubWorkflow", "required": false, "many": false },
+    "pullRequests": { "title": "Pull Requests", "target": "githubPullRequest", "required": false, "many": true },
+    "repository": { "title": "Repository", "target": "githubRepository", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/incident.json
+++ b/port/blueprints/incident.json
@@ -1,0 +1,46 @@
+{
+  "identifier": "incident",
+  "title": "Incident",
+  "icon": "Alert",
+  "schema": {
+    "properties": {
+      "severity": { "title": "Severity", "type": "string", "enum": ["sev1", "sev2", "sev3", "sev4"] },
+      "status": { "title": "Status", "type": "string", "enum": ["active", "investigating", "mitigating", "resolved", "closed"] },
+      "description": { "title": "Description", "type": "string", "format": "markdown" },
+      "alert_source": { "type": "string", "enum": ["pagerduty", "datadog", "prometheus", "manual", "sentry", "dynatrace"], "title": "Alert Source" },
+      "business_impact": { "title": "Business Impact", "type": "string", "format": "markdown" },
+      "impacted_customer_count": { "title": "Impacted Customer Count", "type": "number" },
+      "estimated_revenue_impact": { "title": "Estimated Revenue Impact ($)", "type": "number" },
+      "alerted_at": { "title": "Alerted At", "type": "string", "format": "date-time" },
+      "resolved_at": { "title": "Resolved At", "type": "string", "format": "date-time" },
+      "mttr_minutes": { "title": "MTTR (minutes)", "type": "number" },
+      "ai_suggested_severity": { "title": "AI Suggested Severity", "type": "string" },
+      "ai_suggested_root_cause": { "title": "AI Suggested Root Cause", "type": "string", "format": "markdown" },
+      "ai_remediation_plan": { "title": "AI Remediation Plan", "type": "string", "format": "markdown" },
+      "internal_comms_message": { "title": "Internal Comms Message", "type": "string", "format": "markdown" },
+      "status_page_message": { "title": "Status Page Message", "type": "string", "format": "markdown" },
+      "runbook_url": { "title": "Runbook URL", "type": "string", "format": "url" },
+      "war_room_url": { "title": "War Room URL", "type": "string", "format": "url" },
+      "postmortem_content": { "title": "Postmortem Content", "type": "string", "format": "markdown" },
+      "ai_suggested_postmortem": { "title": "AI Suggested Postmortem", "type": "string", "format": "markdown" },
+      "ai_suggested_owner": { "title": "AI Suggested Owner", "type": "string", "format": "user" },
+      "ai_suggested_response_team": { "title": "AI Suggested Response Team", "type": "string", "format": "team" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "service_tier": { "title": "Service Tier", "path": "primary_service.tier" },
+    "pr_status": { "title": "PR Status", "path": "remediation_pr.status" },
+    "pr_link": { "title": "PR Link", "path": "remediation_pr.link" }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "primary_service": { "target": "service", "required": false, "many": false },
+    "remediation_pr": { "target": "githubPullRequest", "required": false, "many": false },
+    "response_team": { "target": "_team", "required": false, "many": false },
+    "affected_services": { "target": "service", "required": false, "many": true },
+    "related_incidents": { "target": "incident", "required": false, "many": true },
+    "owner": { "target": "_user", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/jiraIssue.json
+++ b/port/blueprints/jiraIssue.json
@@ -1,0 +1,45 @@
+{
+  "identifier": "jiraIssue",
+  "title": "Jira Issue",
+  "icon": "Jira",
+  "ownership": { "type": "Inherited", "path": "assignee" },
+  "schema": {
+    "properties": {
+      "url": { "title": "Issue URL", "type": "string", "format": "url" },
+      "status": { "title": "Status", "type": "string" },
+      "issueType": { "title": "Type", "type": "string" },
+      "components": { "title": "Components", "type": "array" },
+      "creator": { "title": "Creator", "type": "string", "format": "user" },
+      "priority": { "title": "Priority", "type": "string" },
+      "labels": { "title": "Labels", "type": "array" },
+      "created": { "title": "Created At", "type": "string", "format": "date-time" },
+      "updated": { "title": "Updated At", "type": "string", "format": "date-time" },
+      "resolutionDate": { "title": "Resolved At", "type": "string", "format": "date-time" },
+      "description": { "title": "Description", "type": "string", "format": "markdown" },
+      "confidence_score": { "title": "AI Confidence Score", "type": "number" },
+      "triage_status": { "title": "AI Triage Status", "type": "string", "enum": ["Awaiting approval", "Not started", "Draft", "Approved"] },
+      "ai_assignment_reasoning": { "title": "AI Assignment Reasoning", "type": "string" },
+      "assignment_source": { "title": "Ownership Assignment Source", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "pull_request_link": { "title": "Pull Request Link", "path": "pull_request.link" }
+  },
+  "calculationProperties": {
+    "handlingDuration": { "title": "Handling Duration (Days)", "calculation": "if (.properties.resolutionDate != null and .properties.created != null) then ((.properties.resolutionDate[0:19] + \"Z\" | fromdateiso8601) - (.properties.created[0:19] + \"Z\" | fromdateiso8601)) / 86400 else null end", "type": "number" }
+  },
+  "aggregationProperties": {},
+  "relations": {
+    "jira_user_reporter": { "title": "Reporter (Jira User)", "target": "jiraUser", "required": false, "many": false },
+    "pull_request": { "title": "Pull Request", "target": "githubPullRequest", "required": false, "many": false },
+    "assignee": { "title": "Assignee", "target": "_user", "required": false, "many": false },
+    "jira_user_assignee": { "title": "Assignee (Jira User)", "target": "jiraUser", "required": false, "many": false },
+    "subtasks": { "title": "Subtasks", "target": "jiraIssue", "required": false, "many": true },
+    "parentIssue": { "title": "Parent Issue", "target": "jiraIssue", "required": false, "many": false },
+    "repository": { "title": "Repository", "target": "githubRepository", "required": false, "many": false },
+    "ai_discovered_team": { "title": "AI Discovered Team", "target": "_team", "required": false, "many": false },
+    "reporter": { "title": "Reporter", "target": "_user", "required": false, "many": false },
+    "project": { "title": "Project", "target": "jiraProject", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/jiraProject.json
+++ b/port/blueprints/jiraProject.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "jiraProject",
+  "title": "Jira Project",
+  "icon": "Jira",
+  "schema": {
+    "properties": {
+      "url": { "title": "Project URL", "type": "string", "format": "url" },
+      "success_criteria_definition": { "title": "Success Criteria Definition", "type": "string", "format": "markdown" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/jiraUser.json
+++ b/port/blueprints/jiraUser.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "jiraUser",
+  "title": "Jira User",
+  "icon": "Jira",
+  "schema": {
+    "properties": {
+      "emailAddress": { "title": "Email", "type": "string", "format": "email" },
+      "displayName": { "title": "Display Name", "type": "string" },
+      "active": { "title": "Active Status", "type": "boolean" },
+      "accountType": { "title": "Account Type", "type": "string" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/mcpRegistry.json
+++ b/port/blueprints/mcpRegistry.json
@@ -1,0 +1,27 @@
+{
+  "identifier": "mcpRegistry",
+  "title": "MCP Registry",
+  "icon": "Microservice",
+  "schema": {
+    "properties": {
+      "type": { "title": "Server Type", "type": "string", "enum": ["internal", "external"] },
+      "status": { "title": "Approval Status", "type": "string", "enum": ["approved", "pending", "rejected"] },
+      "description": { "title": "Description", "type": "string", "format": "markdown" },
+      "labels": { "title": "Labels", "type": "array", "items": { "type": "string" } },
+      "installation_instructions": { "title": "Installation Instructions", "type": "string", "format": "markdown" },
+      "repository_url": { "title": "Repository URL", "type": "string", "format": "url" },
+      "endpoint": { "title": "Endpoint", "type": "string" },
+      "command": { "title": "Command", "type": "string" },
+      "tools": { "title": "Available Tools", "type": "array", "items": { "type": "string" } },
+      "prompts": { "title": "Available Prompts", "type": "array", "items": { "type": "string" } }
+    },
+    "required": ["type", "status", "description"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "owningTeam": { "title": "Owning Team", "target": "_team", "required": false, "many": false },
+    "requestedBy": { "title": "Requested By", "target": "_user", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/organization.json
+++ b/port/blueprints/organization.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "organization",
+  "title": "Organization",
+  "icon": "Organization",
+  "description": "A logical organization grouping teams and services",
+  "schema": { "properties": {}, "required": [] },
+  "mirrorProperties": {},
+  "calculationProperties": {
+    "github_cycle_time_trend": { "title": "PR Cycle Time Trend", "calculation": "((.properties.github_pr_cycle_time // 0) - (.properties.github_pr_cycle_time_weekly // 0)) as $diff | if $diff > 0 then \"Improving\" elif $diff < 0 then \"Degrading\" else \"Stable\" end", "type": "string" },
+    "github_stale_pr_share_percent": { "title": "Stale PR Share (%)", "calculation": "if (.properties.github_open_prs != null and .properties.github_open_prs != 0) then (.properties.github_stale_prs_7d / .properties.github_open_prs) * 100 else 0 end", "type": "number" }
+  },
+  "aggregationProperties": {
+    "github_open_prs": { "title": "Open PRs", "type": "number", "target": "githubPullRequest", "query": { "combinator": "and", "rules": [{ "operator": "=", "property": "status", "value": "open" }] }, "calculationSpec": { "calculationBy": "entities", "func": "count" } }
+  },
+  "relations": {}
+}

--- a/port/blueprints/service.json
+++ b/port/blueprints/service.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "service",
+  "title": "Service",
+  "icon": "Microservice",
+  "ownership": { "type": "Direct" },
+  "schema": {
+    "properties": {
+      "last_commit_date": { "title": "Last Commit Date", "type": "string", "format": "date-time" },
+      "tier": { "title": "Tier", "type": "number" },
+      "criticality": { "title": "Criticality", "type": "string" },
+      "slack_channel": { "type": "string", "title": "Slack Channel" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "repo_id": { "title": "Repo ID", "path": "repository.$identifier" }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "consumed_by": { "title": "Consumed By", "target": "service", "required": false, "many": true },
+    "last_committer": { "title": "Last Committer", "target": "_user", "required": false, "many": false },
+    "depends_on": { "title": "Depends On", "target": "service", "required": false, "many": true },
+    "repository": { "title": "Repository", "target": "githubRepository", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/skill.json
+++ b/port/blueprints/skill.json
@@ -1,0 +1,20 @@
+{
+  "identifier": "skill",
+  "title": "Skill",
+  "icon": "Learn",
+  "ownership": { "type": "Direct", "title": "Owner" },
+  "schema": {
+    "properties": {
+      "description": { "title": "Description", "type": "string" },
+      "instructions": { "title": "Instructions", "type": "string", "format": "markdown" },
+      "references": { "title": "References", "type": "array" },
+      "assets": { "title": "Assets", "type": "array" },
+      "content": { "title": "content", "type": "object" }
+    },
+    "required": ["description", "instructions"]
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
+}

--- a/port/blueprints/wizControl.json
+++ b/port/blueprints/wizControl.json
@@ -1,20 +1,11 @@
 {
   "identifier": "wizControl",
-  "description": "This blueprint represents a wiz source rule",
   "title": "Wiz Control",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "controlDescription": {
-        "type": "string",
-        "title": "Control Description",
-        "description": "the control description"
-      },
-      "resolutionRecommendation": {
-        "type": "string",
-        "title": "Control Recommendation",
-        "description": "the control recommendation on resolving issues"
-      }
+      "controlDescription": { "title": "Control Description", "type": "string" },
+      "resolutionRecommendation": { "title": "Control Recommendation", "type": "string" }
     },
     "required": []
   },

--- a/port/blueprints/wizHostedTechnology.json
+++ b/port/blueprints/wizHostedTechnology.json
@@ -1,32 +1,14 @@
 {
   "identifier": "wizHostedTechnology",
-  "description": "This blueprint represents a wiz hosted technology",
   "title": "Wiz Hosted Technology",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "detectionMethods": {
-        "title": "Detection Methods",
-        "type": "array"
-      },
-      "installedPackages": {
-        "title": "Installed Packages",
-        "type": "array"
-      },
-      "firstSeen": {
-        "title": "First Seen",
-        "type": "string",
-        "format": "date-time"
-      },
-      "updatedAt": {
-        "title": "Updated At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "cpe": {
-        "title": "CPE",
-        "type": "string"
-      }
+      "detectionMethods": { "title": "Detection Methods", "type": "array" },
+      "installedPackages": { "title": "Installed Packages", "type": "array" },
+      "firstSeen": { "title": "First Seen", "type": "string", "format": "date-time" },
+      "updatedAt": { "title": "Updated At", "type": "string", "format": "date-time" },
+      "cpe": { "title": "CPE", "type": "string" }
     },
     "required": []
   },
@@ -34,12 +16,6 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "technology": {
-      "title": "Technology",
-      "description": "The technology that this hosted technology is associated with",
-      "target": "wizTechnology",
-      "required": false,
-      "many": false
-    }
+    "technology": { "title": "Technology", "target": "wizTechnology", "required": false, "many": false }
   }
 }

--- a/port/blueprints/wizIssue.json
+++ b/port/blueprints/wizIssue.json
@@ -1,141 +1,25 @@
 {
   "identifier": "wizIssue",
-  "description": "This blueprint represents a wiz issue",
   "title": "Wiz Issue",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "url": {
-        "type": "string",
-        "title": "Issue URL",
-        "format": "url",
-        "description": "the link to the issue"
-      },
-      "status": {
-        "title": "Status",
-        "type": "string",
-        "enum": [
-          "OPEN",
-          "IN_PROGRESS",
-          "RESOLVED",
-          "REJECTED"
-        ],
-        "enumColors": {
-          "OPEN": "blue",
-          "IN_PROGRESS": "orange",
-          "RESOLVED": "green",
-          "REJECTED": "darkGray"
-        }
-      },
-      "severity": {
-        "title": "Severity",
-        "type": "string",
-        "enum": [
-          "INFORMATIONAL",
-          "LOW",
-          "MEDIUM",
-          "HIGH",
-          "CRITICAL"
-        ],
-        "enumColors": {
-          "INFORMATIONAL": "blue",
-          "LOW": "yellow",
-          "MEDIUM": "orange",
-          "HIGH": "red",
-          "CRITICAL": "red"
-        }
-      },
-      "vulnerabilityType": {
-        "title": "Vulnerability Type",
-        "type": "string"
-      },
-      "wizIssueID": {
-        "title": "Wiz Issue ID",
-        "type": "string"
-      },
-      "cloudResourceType": {
-        "title": "Cloud Resource Type",
-        "type": "string"
-      },
-      "resourceName": {
-        "title": "Resource Name",
-        "type": "string"
-      },
-      "cloudPlatform": {
-        "title": "Cloud Platform",
-        "type": "string"
-      },
-      "linkToResource": {
-        "icon": "Wiz",
-        "title": "Link to Cloud Resource",
-        "type": "string",
-        "format": "url"
-      },
-      "cloudResourceID": {
-        "title": "Cloud Resource ID",
-        "type": "string"
-      },
-      "cloudRegion": {
-        "title": "Cloud Region",
-        "type": "string"
-      },
-      "resourceGroupExternalId": {
-        "title": "Resource Group External ID",
-        "type": "string"
-      },
-      "subscriptionExternalId": {
-        "title": "Subscription External ID",
-        "type": "string"
-      },
-      "subscriptionName": {
-        "title": "Subscription Name",
-        "type": "string"
-      },
-      "subscriptionTags": {
-        "title": "Subscription Tags",
-        "type": "object"
-      },
-      "resourceTags": {
-        "title": "Resource Tags",
-        "type": "object"
-      },
-      "vulnerability": {
-        "title": "Vulnerability",
-        "type": "object",
-        "description": "The identified security risk"
-      },
-      "notes": {
-        "title": "Notes",
-        "items": {
-          "type": "string"
-        },
-        "type": "array"
-      },
-      "createdAt": {
-        "title": "Created At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "updatedAt": {
-        "title": "Updated At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "dueAt": {
-        "title": "Due At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "resolvedAt": {
-        "title": "Resolved At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "statusChangedAt": {
-        "title": "Status ChangedAt",
-        "type": "string",
-        "format": "date-time"
-      }
+      "url": { "title": "Issue URL", "type": "string", "format": "url" },
+      "status": { "title": "Status", "type": "string", "enum": ["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"], "enumColors": { "OPEN": "blue", "IN_PROGRESS": "orange", "RESOLVED": "green", "REJECTED": "darkGray" } },
+      "severity": { "title": "Severity", "type": "string", "enum": ["INFORMATIONAL", "LOW", "MEDIUM", "HIGH", "CRITICAL"] },
+      "vulnerabilityType": { "title": "Vulnerability Type", "type": "string" },
+      "wizIssueID": { "title": "Wiz Issue ID", "type": "string" },
+      "cloudResourceType": { "title": "Cloud Resource Type", "type": "string" },
+      "resourceName": { "title": "Resource Name", "type": "string" },
+      "cloudPlatform": { "title": "Cloud Platform", "type": "string" },
+      "linkToResource": { "title": "Link to Cloud Resource", "type": "string", "format": "url" },
+      "cloudResourceID": { "title": "Cloud Resource ID", "type": "string" },
+      "cloudRegion": { "title": "Cloud Region", "type": "string" },
+      "createdAt": { "title": "Created At", "type": "string", "format": "date-time" },
+      "updatedAt": { "title": "Updated At", "type": "string", "format": "date-time" },
+      "dueAt": { "title": "Due At", "type": "string", "format": "date-time" },
+      "resolvedAt": { "title": "Resolved At", "type": "string", "format": "date-time" },
+      "statusChangedAt": { "title": "Status ChangedAt", "type": "string", "format": "date-time" }
     },
     "required": []
   },
@@ -143,26 +27,8 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "control": {
-      "title": "Control",
-      "description": "The control that flagged this issue",
-      "target": "wizControl",
-      "required": false,
-      "many": false
-    },
-    "serviceTickets": {
-      "title": "Service Tickets",
-      "description": "The service tickets belonging to this issue",
-      "target": "wizServiceTicket",
-      "required": false,
-      "many": true
-    },
-    "projects": {
-      "title": "Affected Projects",
-      "description": "The projects affected by this issue",
-      "target": "wizProject",
-      "required": false,
-      "many": true
-    }
+    "projects": { "title": "Affected Projects", "target": "wizProject", "required": false, "many": true },
+    "serviceTickets": { "title": "Service Tickets", "target": "wizServiceTicket", "required": false, "many": true },
+    "control": { "title": "Control", "target": "wizControl", "required": false, "many": false }
   }
 }

--- a/port/blueprints/wizProject.json
+++ b/port/blueprints/wizProject.json
@@ -1,25 +1,12 @@
 {
   "identifier": "wizProject",
-  "description": "This blueprint represents a wiz project",
   "title": "Wiz Project",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "archived": {
-        "type": "boolean",
-        "title": "Archived?",
-        "description": "Is the project archived?"
-      },
-      "businessUnit": {
-        "type": "string",
-        "title": "Business Unit",
-        "description": "the business unit of the project"
-      },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "the project description"
-      }
+      "archived": { "title": "Archived?", "type": "boolean" },
+      "businessUnit": { "title": "Business Unit", "type": "string" },
+      "description": { "title": "Description", "type": "string" }
     },
     "required": []
   },
@@ -27,12 +14,6 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "issues": {
-      "title": "Issues",
-      "description": "The issues affecting this project",
-      "target": "wizIssue",
-      "required": false,
-      "many": true
-    }
+    "issues": { "title": "Issues", "target": "wizIssue", "required": false, "many": true }
   }
 }

--- a/port/blueprints/wizRepository.json
+++ b/port/blueprints/wizRepository.json
@@ -1,39 +1,16 @@
 {
   "identifier": "wizRepository",
-  "description": "This blueprint represents a wiz repository",
   "title": "Wiz Repository",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "url": {
-        "title": "URL",
-        "type": "string",
-        "format": "url"
-      },
-      "platform": {
-        "title": "Platform",
-        "type": "string"
-      },
-      "public": {
-        "title": "Public",
-        "type": "boolean"
-      },
-      "archived": {
-        "title": "Archived",
-        "type": "boolean"
-      },
-      "visibility": {
-        "title": "Visibility",
-        "type": "string"
-      },
-      "organization": {
-        "title": "Organization",
-        "type": "string"
-      },
-      "branches": {
-        "title": "Branches",
-        "type": "array"
-      }
+      "url": { "title": "URL", "type": "string", "format": "url" },
+      "platform": { "title": "Platform", "type": "string" },
+      "public": { "title": "Public", "type": "boolean" },
+      "archived": { "title": "Archived", "type": "boolean" },
+      "visibility": { "title": "Visibility", "type": "string" },
+      "organization": { "title": "Organization", "type": "string" },
+      "branches": { "title": "Branches", "type": "array" }
     },
     "required": []
   },
@@ -41,11 +18,6 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "projects": {
-      "title": "Projects",
-      "target": "wizProject",
-      "required": false,
-      "many": false
-    }
+    "projects": { "title": "Projects", "target": "wizProject", "required": false, "many": false }
   }
 }

--- a/port/blueprints/wizServiceTicket.json
+++ b/port/blueprints/wizServiceTicket.json
@@ -1,16 +1,10 @@
 {
   "identifier": "wizServiceTicket",
-  "description": "This blueprint represents a wiz service ticket",
   "title": "Wiz Service Ticket",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "url": {
-        "type": "string",
-        "title": "Ticket URL",
-        "format": "url",
-        "description": "the service ticket URL"
-      }
+      "url": { "title": "Ticket URL", "type": "string", "format": "url" }
     },
     "required": []
   },

--- a/port/blueprints/wizTechnology.json
+++ b/port/blueprints/wizTechnology.json
@@ -1,62 +1,18 @@
 {
   "identifier": "wizTechnology",
-  "description": "This blueprint represents a wiz technology",
   "title": "Wiz Technology",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "description": {
-        "title": "Description",
-        "type": "string"
-      },
-      "categories": {
-        "title": "Categories",
-        "type": "array"
-      },
-      "usage": {
-        "title": "Usage",
-        "type": "string"
-      },
-      "status": {
-        "title": "Status",
-        "type": "string"
-      },
-      "risk": {
-        "title": "Risk",
-        "type": "string"
-      },
-      "note": {
-        "title": "Note",
-        "type": "string"
-      },
-      "ownerName": {
-        "title": "Owner Name",
-        "type": "string"
-      },
-      "businessModel": {
-        "title": "Business Model",
-        "type": "string"
-      },
-      "popularity": {
-        "title": "Popularity",
-        "type": "number"
-      },
-      "projectCount": {
-        "title": "Project Count",
-        "type": "number"
-      },
-      "codeRepoCount": {
-        "title": "Code Repo Count",
-        "type": "number"
-      },
-      "isCloudService": {
-        "title": "Is Cloud Service",
-        "type": "boolean"
-      },
-      "supportedOperatingSystems": {
-        "title": "Supported Operating Systems",
-        "type": "array"
-      }
+      "description": { "title": "Description", "type": "string" },
+      "categories": { "title": "Categories", "type": "array" },
+      "usage": { "title": "Usage", "type": "string" },
+      "status": { "title": "Status", "type": "string" },
+      "risk": { "title": "Risk", "type": "string" },
+      "ownerName": { "title": "Owner Name", "type": "string" },
+      "popularity": { "title": "Popularity", "type": "number" },
+      "projectCount": { "title": "Project Count", "type": "number" },
+      "isCloudService": { "title": "Is Cloud Service", "type": "boolean" }
     },
     "required": []
   },

--- a/port/blueprints/wizVulnerabilityFinding.json
+++ b/port/blueprints/wizVulnerabilityFinding.json
@@ -1,142 +1,24 @@
 {
   "identifier": "wizVulnerabilityFinding",
-  "description": "This blueprint represents a wiz vulnerability finding",
   "title": "Wiz Vulnerability Finding",
   "icon": "Wiz",
   "schema": {
     "properties": {
-      "status": {
-        "title": "Status",
-        "type": "string",
-        "enum": [
-          "OPEN",
-          "IN_PROGRESS",
-          "RESOLVED",
-          "REJECTED"
-        ],
-        "enumColors": {
-          "OPEN": "red",
-          "IN_PROGRESS": "yellow",
-          "RESOLVED": "green",
-          "REJECTED": "lightGray"
-        }
-      },
-      "severity": {
-        "title": "Severity",
-        "type": "string",
-        "enum": [
-          "LOW",
-          "MEDIUM",
-          "HIGH",
-          "CRITICAL",
-          "NONE"
-        ],
-        "enumColors": {
-          "LOW": "olive",
-          "MEDIUM": "yellow",
-          "HIGH": "red",
-          "CRITICAL": "red",
-          "NONE": "lightGray"
-        }
-      },
-      "categories": {
-        "title": "Categories",
-        "type": "array"
-      },
-      "version": {
-        "title": "Version",
-        "type": "string"
-      },
-      "detectionMethod": {
-        "title": "Detection Method",
-        "type": "string"
-      },
-      "score": {
-        "title": "Score",
-        "type": "number"
-      },
-      "description": {
-        "title": "Description",
-        "type": "string"
-      },
-      "firstDetectedAt": {
-        "title": "First Detected At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "publishedDate": {
-        "title": "Published Date",
-        "type": "string",
-        "format": "date-time"
-      },
-      "remediation": {
-        "title": "Remediation",
-        "type": "string"
-      },
-      "environments": {
-        "title": "Environments",
-        "type": "array"
-      },
-      "link": {
-        "title": "Link",
-        "type": "string",
-        "format": "url"
-      },
-      "vulnerabilityExternalId": {
-        "title": "Vulnerability External ID",
-        "type": "string"
-      },
-      "portalUrl": {
-        "title": "Portal URL",
-        "type": "string",
-        "format": "url"
-      },
-      "origin": {
-        "title": "Origin",
-        "type": "string"
-      },
-      "CVEDescription": {
-        "title": "CVE Description",
-        "type": "string"
-      },
-      "hasFix": {
-        "title": "Has Fix",
-        "type": "boolean"
-      },
-      "hasExploit": {
-        "title": "Has Exploit",
-        "type": "boolean"
-      },
-      "isHighProfileThreat": {
-        "title": "Is High Profile Threat",
-        "type": "boolean"
-      },
-      "rootComponent": {
-        "title": "Root Component",
-        "type": "object"
-      },
-      "applicationServices": {
-        "title": "Application Services",
-        "type": "array"
-      },
-      "updatedAt": {
-        "title": "Updated At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "resolvedAt": {
-        "title": "Resolved At",
-        "type": "string",
-        "format": "date-time"
-      },
-      "detailedName": {
-        "type": "string",
-        "title": "Detailed Name"
-      },
-      "artifactMetadata": {
-        "type": "object",
-        "title": "Artifact Metadata"
-      }
+      "status": { "title": "Status", "type": "string", "enum": ["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"] },
+      "severity": { "title": "Severity", "type": "string", "enum": ["LOW", "MEDIUM", "HIGH", "CRITICAL", "NONE"] },
+      "categories": { "title": "Categories", "type": "array" },
+      "version": { "title": "Version", "type": "string" },
+      "detectionMethod": { "title": "Detection Method", "type": "string" },
+      "score": { "title": "Score", "type": "number" },
+      "description": { "title": "Description", "type": "string" },
+      "firstDetectedAt": { "title": "First Detected At", "type": "string", "format": "date-time" },
+      "hasFix": { "title": "Has Fix", "type": "boolean" },
+      "hasExploit": { "title": "Has Exploit", "type": "boolean" },
+      "isHighProfileThreat": { "title": "Is High Profile Threat", "type": "boolean" },
+      "link": { "title": "Link", "type": "string", "format": "url" },
+      "portalUrl": { "title": "Portal URL", "type": "string", "format": "url" },
+      "updatedAt": { "title": "Updated At", "type": "string", "format": "date-time" },
+      "resolvedAt": { "title": "Resolved At", "type": "string", "format": "date-time" }
     },
     "required": []
   },
@@ -144,12 +26,6 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "projects": {
-      "title": "Projects",
-      "description": "The projects affected by this vulnerability finding",
-      "target": "wizProject",
-      "required": false,
-      "many": true
-    }
+    "projects": { "title": "Projects", "target": "wizProject", "required": false, "many": true }
   }
 }

--- a/port/blueprints/work_item.json
+++ b/port/blueprints/work_item.json
@@ -1,0 +1,37 @@
+{
+  "identifier": "work_item",
+  "title": "Work item",
+  "icon": "Travel",
+  "schema": {
+    "properties": {
+      "priority": { "title": "Priority", "type": "string", "enum": ["critical", "high", "medium", "low"], "enumColors": { "critical": "red", "high": "orange", "medium": "yellow", "low": "green" } },
+      "plan_approved": { "title": "Plan Approved", "type": "boolean" },
+      "work_type": { "title": "Work Type", "type": "string", "enum": ["feature", "bug", "incident", "task"] },
+      "description": { "title": "Description", "type": "string", "format": "markdown" },
+      "ai_augmentation_level": { "title": "AI Augmentation Level", "type": "string", "enum": ["Human", "AI assisted", "AI led", "Autonomous"] },
+      "completed_at": { "title": "Completed At", "type": "string", "format": "date-time" },
+      "blast_radius_risk_score": { "title": "Blast Radius Risk Score", "type": "number" },
+      "blast_radius_analysis": { "title": "AI generated Blast Radius Analysis", "type": "string", "format": "markdown" },
+      "ai_prep_status": { "title": "AI Prep Status", "type": "string", "enum": ["Not started", "In review", "Awaiting approval", "Approved"] },
+      "ai_prep_confidence_score": { "title": "AI Prep Confidence Score", "type": "number" },
+      "ai_prep_notes": { "title": "AI Prep Notes", "type": "string", "format": "markdown" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "pr_status": { "title": "PR Status", "path": "pull_request.status" },
+    "pr_link": { "title": "PR Link", "path": "pull_request.link" },
+    "jira_status": { "title": "Jira Status", "path": "jira_ticket.status" },
+    "service_tier": { "title": "Service Tier", "path": "service.tier" }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "owner": { "title": "Owner", "target": "_user", "required": false, "many": false },
+    "target_environment": { "title": "Target Environment", "target": "environment", "required": false, "many": false },
+    "jira_ticket": { "title": "Jira Ticket", "target": "jiraIssue", "required": false, "many": false },
+    "service": { "title": "Service", "target": "service", "required": false, "many": false },
+    "pull_request": { "title": "Pull Request", "target": "githubPullRequest", "required": false, "many": false },
+    "team": { "title": "Team", "target": "_team", "required": false, "many": false }
+  }
+}

--- a/port/blueprints/workload.json
+++ b/port/blueprints/workload.json
@@ -1,0 +1,17 @@
+{
+  "identifier": "workload",
+  "title": "Workload",
+  "icon": "Deployment",
+  "schema": {
+    "properties": {
+      "version": { "type": "string", "title": "Version" }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "environment": { "title": "Environment", "target": "environment", "required": false, "many": false }
+  }
+}


### PR DESCRIPTION
# Port Configuration Backup — 2026-05-26\n\nThis PR backs up the full current state of all **blueprints** and **actions** defined in Port as individual JSON files.\n\n## 📦 Blueprints backed up (38 files → `port/blueprints/`)\n\n| Category | Blueprints |\n|---|---|\n| **Core** | `_user`, `_team`, `organization`, `environment`, `service` |\n| **GitHub** | `githubRepository`, `githubPullRequest`, `githubWorkflow`, `githubWorkflowRun`, `githubTeam`, `githubUser`, `githubOrganization` |\n| **Jira** | `jiraIssue`, `jiraProject`, `jiraUser` |\n| **Wiz** | `wizIssue`, `wizVulnerabilityFinding`, `wizControl`, `wizProject`, `wizRepository`, `wizTechnology`, `wizServiceTicket`, `wizHostedTechnology` |\n| **AI / Claude** | `_ai_agent`, `_ai_invocations`, `claude_usage_record`, `claude_cost_record`, `claude_model_usage`, `claude_workspace_usage`, `claude_code_analytics` |\n| **Scorecards** | `_scorecard`, `_rule`, `_rule_result` |\n| **Other** | `deployment`, `workload`, `work_item`, `skill`, `mcpRegistry`, `_mcp_server` |\n\n## ⚡ Actions backed up (15 files → `port/actions/`)\n\n| Type | Actions |\n|---|---|\n| **Self-service** | `_onboard_your_user`, `_onboard_existing_team`, `set_ownership`, `update_incident_triage`, `invoke_cursor_agent`, `run_claude_code`, `request_mcp_server`, `send_a_slack_message` |\n| **Automation** | `set_parent_team_relations`, `set_github_deployment_relations`, `set_pull_request_relations`, `set_pull_request_user_relations`, `set_workflow_run_relations`, `incident_triage_automation`, `trigger_ci_failure_cursor_fixer` |\n\n---\n*Generated automatically by Port AI on 2026-05-26*"